### PR TITLE
Handle client side errors ranging from 400-499

### DIFF
--- a/src/Middleware/CommandMiddleware.php
+++ b/src/Middleware/CommandMiddleware.php
@@ -79,16 +79,13 @@ class CommandMiddleware
      */
     private function getStatusErrorCodeFromException(\Exception $e)
     {
-        switch ($e->getCode()) {
-            //@TODO: complete list of supported status error codes
-            case 400:
-            case 405:
-            case 404:
-            case 422:
-                return $e->getCode();
-            default:
-                return 500;
+        $code = $e->getCode();
+        
+        if ($code >= 400 or $code < 500) {
+            return $code;
         }
+        
+        return 500;
     }
 
     /**


### PR DESCRIPTION
All 4XX status codes are client errors.

https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error
