### PR TITLE
No need to use call_user_func_array

### DIFF
--- a/src/Middleware/CommandMiddleware.php
+++ b/src/Middleware/CommandMiddleware.php
@@ -55,7 +55,7 @@ class CommandMiddleware
                 throw new \RuntimeException("Command associated with the path $path is not callable");
             }
 
-            $command = call_user_func_array($command, [$payload]);
+            $command = call_user_func($command, $payload);
 
             $this->commandBus->dispatch($command);
 


### PR DESCRIPTION
No need to use `call_user_func_array` as `call_user_func` should be sufficient?

Just there is no dynamic arguments its just `$payload` that is given.
